### PR TITLE
Set table size in BDDL

### DIFF
--- a/mimiclabs/mimiclabs/envs/bddl_base_domain.py
+++ b/mimiclabs/mimiclabs/envs/bddl_base_domain.py
@@ -157,6 +157,16 @@ class BDDLBaseDomain(RobosuiteEnv):
         self.bddl_file_name = bddl_file_name
         self.parsed_problem = BDDLUtils.robosuite_parse_problem(self.bddl_file_name)
 
+        # Override table_full_size if specified in bddl
+        if "table_params" in self.parsed_problem:
+            if "size" in self.parsed_problem["table_params"]:
+                table_size = self.parsed_problem["table_params"]["size"]
+                # Set table length and width (used for resizing geoms in TableArena)
+                self.table_full_size = (table_size[0], table_size[1], self.table_full_size[2])
+                # Set table height in table_offset and workspace_offset
+                self.table_offset = (self.table_offset[0], self.table_offset[1], table_size[2])
+                self.workspace_offset = self.table_offset
+
         self.obj_of_interest = self.parsed_problem["obj_of_interest"]
 
         self._assert_problem_name()

--- a/mimiclabs/mimiclabs/envs/bddl_utils.py
+++ b/mimiclabs/mimiclabs/envs/bddl_utils.py
@@ -74,6 +74,16 @@ def get_camera_poses(group):
     ], f"Camera pose unit should be radians or degrees, {camera['unit']} not supported."
     return camera
 
+def get_table_params(group):
+    """Parse table parameters (size as [width, length, height]) from BDDL."""
+    table_params = {}
+    for subgrp in group[1:]:
+        if subgrp[0] == ":size":
+            # Parse size as a list of 3 values: width, length, height
+            size_values = [eval(val) for val in subgrp[1:]]
+            table_params["size"] = size_values
+    return table_params
+
 
 def robosuite_parse_problem(problem_filename):
     if problem_filename.endswith(".json"):
@@ -89,6 +99,7 @@ def robosuite_parse_problem(problem_filename):
         textures = {}
         camera = {}
         lighting = {}
+        table_params = {}
         obj_of_interest = []
         initial_state = []
         goal_state = []
@@ -125,6 +136,8 @@ def robosuite_parse_problem(problem_filename):
                 textures = get_textures(group)
             elif t == ":camera":
                 camera = get_camera_poses(group)
+            elif t == ":table":
+                table_params = get_table_params(group)
             elif t == ":lighting":
                 lighting["source"] = []
                 for subgrp in group[1:]:
@@ -178,6 +191,7 @@ def robosuite_parse_problem(problem_filename):
             "objects": objects,
             "textures": textures,
             "camera": camera,
+            "table_params": table_params,
             "lighting": lighting,
             "scene_properties": scene_properties,
             "initial_state": initial_state,


### PR DESCRIPTION
Added ability to specify table size in the BDDL.

Example:
`
  (:table
    (:size 0.8 0.8 0.9)
  )
`
where the dimensions are length (x), width (y), and height of the table-top, respectively.

### Task resets:

Table size `0.8, 0.8, 0.9`

https://github.com/user-attachments/assets/3c2e93c4-7495-497a-8312-4632697a9d45

Table size `0.8, 1.2, 0.7`

https://github.com/user-attachments/assets/f9f5b873-8f0e-4715-8870-54c02891537f



Note that the agentview camera is fixated at the center of the table.
