### PR TITLE
Added primitive mujoco cuboid object

### DIFF
--- a/mimiclabs/mimiclabs/envs/bddl_base_domain.py
+++ b/mimiclabs/mimiclabs/envs/bddl_base_domain.py
@@ -345,7 +345,7 @@ class BDDLBaseDomain(RobosuiteEnv):
         """
         raise NotImplementedError
 
-    def _load_objects_in_arena(self, mujoco_arena):
+    def _load_objects_in_arena(self, mujoco_arena, object_params):
         """
         Load movable objects based on the bddl file description
         """
@@ -465,7 +465,7 @@ class BDDLBaseDomain(RobosuiteEnv):
 
         self._load_fixtures_in_arena(mujoco_arena)
 
-        self._load_objects_in_arena(mujoco_arena)
+        self._load_objects_in_arena(mujoco_arena, self.parsed_problem["object_params"])
 
         self._load_sites_in_arena(mujoco_arena)
 

--- a/mimiclabs/mimiclabs/envs/bddl_base_domain.py
+++ b/mimiclabs/mimiclabs/envs/bddl_base_domain.py
@@ -162,9 +162,17 @@ class BDDLBaseDomain(RobosuiteEnv):
             if "size" in self.parsed_problem["table_params"]:
                 table_size = self.parsed_problem["table_params"]["size"]
                 # Set table length and width (used for resizing geoms in TableArena)
-                self.table_full_size = (table_size[0], table_size[1], self.table_full_size[2])
+                self.table_full_size = (
+                    table_size[0],
+                    table_size[1],
+                    self.table_full_size[2],
+                )
                 # Set table height in table_offset and workspace_offset
-                self.table_offset = (self.table_offset[0], self.table_offset[1], table_size[2])
+                self.table_offset = (
+                    self.table_offset[0],
+                    self.table_offset[1],
+                    table_size[2],
+                )
                 self.workspace_offset = self.table_offset
 
         self.obj_of_interest = self.parsed_problem["obj_of_interest"]

--- a/mimiclabs/mimiclabs/envs/objects/__init__.py
+++ b/mimiclabs/mimiclabs/envs/objects/__init__.py
@@ -10,6 +10,7 @@ from .articulated_objects import *
 from .libero_objects import *
 from .mimicgen_objects import *
 from .objaverse_objects import *
+from .primitive_objects import *
 
 try:
     from .robocasa_objects import *

--- a/mimiclabs/mimiclabs/envs/objects/primitive_objects.py
+++ b/mimiclabs/mimiclabs/envs/objects/primitive_objects.py
@@ -1,0 +1,68 @@
+import numpy as np
+import re
+
+from robosuite.models.objects.primitive.box import BoxObject
+
+from libero.libero.envs.base_object import register_object
+
+
+@register_object
+class MujocoCuboid(BoxObject):
+    """
+    A wrapper around BoxObject that follows the naming convention used in objaverse objects.
+
+    Args:
+        name (str): Name of the object instance
+        obj_name (str): Object type name (used for category naming)
+        joints (list): List of joint specifications. Defaults to a free joint with damping.
+    """
+
+    def __init__(
+        self,
+        name="mujoco_cuboid",
+        obj_name="cuboid",
+        joints=[dict(type="free", damping="0.0005")],
+        size=None,
+        size_max=None,
+        size_min=None,
+        density=None,
+        friction=None,
+        rgba=None,
+        solref=None,
+        solimp=None,
+        material=None,
+        obj_type="all",
+        duplicate_collision_geoms=True,
+    ):
+        # Convert joints list to the format expected by BoxObject
+        # BoxObject expects joints="default" or a list of joint dicts
+        if joints is None:
+            joints_param = None
+        elif len(joints) == 0:
+            joints_param = None
+        else:
+            joints_param = joints
+
+        super().__init__(
+            name=name,
+            size=size,
+            size_max=size_max,
+            size_min=size_min,
+            density=density,
+            friction=friction,
+            rgba=rgba,
+            solref=solref,
+            solimp=solimp,
+            material=material,
+            joints=joints_param,
+            obj_type=obj_type,
+            duplicate_collision_geoms=duplicate_collision_geoms,
+        )
+
+        # Add category name.
+        self.category_name = "_".join(
+            re.sub(r"([A-Z])", r" \1", self.__class__.__name__).split()
+        ).lower()
+        self.rotation = (np.pi / 2, np.pi / 2)
+        self.rotation_axis = "x"
+        self.object_properties = {"vis_site_names": {}}

--- a/mimiclabs/mimiclabs/envs/problems/mimiclabs_tabletop_manipulation.py
+++ b/mimiclabs/mimiclabs/envs/problems/mimiclabs_tabletop_manipulation.py
@@ -53,12 +53,12 @@ class MimicLabs_Tabletop_Manipulation_Base(BDDLBaseDomain):
                     joints=None,
                 )
 
-    def _load_objects_in_arena(self, mujoco_arena):
+    def _load_objects_in_arena(self, mujoco_arena, object_params):
         objects_dict = self.parsed_problem["objects"]
         for category_name in objects_dict.keys():
             for object_name in objects_dict[category_name]:
                 self.objects_dict[object_name] = get_object_fn(category_name)(
-                    name=object_name
+                    name=object_name, **object_params.get(object_name, {})
                 )
 
     def _load_sites_in_arena(self, mujoco_arena):


### PR DESCRIPTION
This PR adds the primitive `mujoco_cuboid` object for MimicLabs envs.

To add a cuboid object, simply add the following to the BDDL (example, two cuboids):
...  
(:objects
    object_1 object_2 - `mujoco_cuboid`
  )
...

You can specify kwargs for the object class as:
...
  (:object_params
    (:object_1
      (:size 0.02 0.02 0.02)
      (:rgba 0.5 0.1 0.1 1.0)
    )
    (:object_2
      (:size 0.02 0.02 0.02)
      (:rgba 0.1 0.5 0.1 1.0)
    )
  )
...

This will create two cubes of edge size 0.02, and colors red and green. For more params, see the `MujocoCuboid` class in `primitive_objects.py`.


https://github.com/user-attachments/assets/7c59f2f9-de23-44db-97fb-0f07a621e2d1

