### PR TITLE
Support agentview camera look_at and intrinsics

### DIFF
--- a/mimiclabs/mimiclabs/envs/bddl_utils.py
+++ b/mimiclabs/mimiclabs/envs/bddl_utils.py
@@ -127,10 +127,15 @@ def get_table_params(group):
     """Parse table parameters (size as [width, length, height]) from BDDL."""
     table_params = {}
     for subgrp in group[1:]:
-        if subgrp[0] == ":size":
-            # Parse size as a list of 3 values: width, length, height
-            size_values = [eval(val) for val in subgrp[1:]]
-            table_params["size"] = size_values
+        param_name = subgrp[0].lstrip(":")
+        param_value = subgrp[1]
+
+        # If param_value is a list, evaluate each element
+        if isinstance(param_value, list):
+            table_params[param_name] = [eval(val) for val in param_value]
+        else:
+            # Single value, evaluate it
+            table_params[param_name] = eval(param_value)
     return table_params
 
 
@@ -146,17 +151,16 @@ def get_object_params(group):
         object_params[obj_name] = {}
 
         for param in obj_group[1:]:
-            # Strip the colon from parameter name
+            # param[0] is the parameter name, param[1] is the value
             param_name = param[0].lstrip(":")
+            param_value = param[1]
 
-            # Evaluate all parameter values
-            param_values = [eval(val) for val in param[1:]]
-
-            # If single value, unwrap from list; otherwise keep as list
-            if len(param_values) == 1:
-                object_params[obj_name][param_name] = param_values[0]
+            # If param_value is a list, evaluate each element
+            if isinstance(param_value, list):
+                object_params[obj_name][param_name] = [eval(val) for val in param_value]
             else:
-                object_params[obj_name][param_name] = param_values
+                # Single value, evaluate it
+                object_params[obj_name][param_name] = eval(param_value)
 
     return object_params
 

--- a/mimiclabs/mimiclabs/envs/problems/mimiclabs_tabletop_manipulation.py
+++ b/mimiclabs/mimiclabs/envs/problems/mimiclabs_tabletop_manipulation.py
@@ -200,40 +200,6 @@ class MimicLabs_Tabletop_Manipulation_Base(BDDLBaseDomain):
                         1 - self.sim.model.site_rgba[vis_g_id][3]
                     )
 
-    def _setup_camera(self, mujoco_arena, agentview_pose=None):
-        if agentview_pose is None:
-            mujoco_arena.set_camera(
-                camera_name="agentview",
-                pos=[1.0, 0, 1.6],
-                quat=[0.5963678, 0.3799282, 0.3799282, 0.5963678],
-            )
-        else:
-            mujoco_arena.set_camera(
-                camera_name="agentview",
-                pos=agentview_pose["pos"],
-                quat=agentview_pose["quat"],
-            )
-
-        # For visualization purpose
-        mujoco_arena.set_camera(
-            camera_name="frontview", pos=[1.0, 0.0, 1.48], quat=[0.56, 0.43, 0.43, 0.56]
-        )
-        mujoco_arena.set_camera(
-            camera_name="galleryview",
-            pos=[2.844547668904445, 2.1279684793440667, 3.128616846013882],
-            quat=[
-                0.42261379957199097,
-                0.23374411463737488,
-                0.41646939516067505,
-                0.7702690958976746,
-            ],
-        )
-        mujoco_arena.set_camera(
-            camera_name="paperview",
-            pos=[2.1, 0.535, 2.075],
-            quat=[0.513, 0.353, 0.443, 0.645],
-        )
-
 
 @register_problem
 class MimicLabs_Lab1_Tabletop_Manipulation(MimicLabs_Tabletop_Manipulation_Base):


### PR DESCRIPTION
## Look at

Agentview camera spec in BDDL now support a `look_at` param, which can either be the `table` fixture (default), or a 3D pos.

_Example 1:_ 

  (:camera
    (:ranges (
        (1.1 45 -15 1.1 60 0)
      )
    )
    (:unit degrees)
    (:jitter_mode uniform)
    (:`look_at` table)
  )

_Example 2:_

  (:camera
    (:ranges (
        (1.1 45 -15 1.1 60 0)
      )
    )
    (:unit degrees)
    (:jitter_mode uniform)
    (:`look_at` (0.5 0.2 0.9))
  )

## Intrinsics

Added support for providing `fovy` and `principal` in BDDL

_Example 1:_ 

  (:camera
    (:ranges (
        (1.1 45 -15 1.1 60 0)
      )
    )
    (:unit degrees)
    (:jitter_mode uniform)
    (:look_at table)
    (:`intrinsics` 
      (:fovy ...)
      (:principal (... ...))
    )
  )

